### PR TITLE
Fix issue with GHA: "Missing download info for actions/checkout@v4"

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -28,7 +28,7 @@ jobs:
           - beta
           - nightly
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v3
       - name: Update Rust
         run: |
           rustup update ${{ matrix.toolchain }} && rustup default ${{ matrix.toolchain }}

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -29,6 +29,8 @@ jobs:
           - nightly
     steps:
       - uses: actions/checkout@v3
+        with:
+          submodules: recursive
       - name: Update Rust
         run: |
           rustup update ${{ matrix.toolchain }} && rustup default ${{ matrix.toolchain }}

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -29,8 +29,6 @@ jobs:
           - nightly
     steps:
       - uses: actions/checkout@v4
-        with:
-          submodules: recursive
       - name: Update Rust
         run: |
           rustup update ${{ matrix.toolchain }} && rustup default ${{ matrix.toolchain }}


### PR DESCRIPTION
Tentative solution: downgrade to `actions/checkout@v3`.